### PR TITLE
Fix linux build

### DIFF
--- a/src/controllers/nerf-training-controller.cu
+++ b/src/controllers/nerf-training-controller.cu
@@ -16,19 +16,19 @@ using namespace nrc;
 using namespace tcnn;
 using namespace nlohmann;
 
-NeRFTrainingController::NeRFTrainingController(Dataset& dataset, NeRFProxy* nerf_proxy, const uint32_t& batch_size)
+NeRFTrainingController::NeRFTrainingController(Dataset& dataset, NeRFProxy* nerf_proxy, const uint32_t batch_size)
 	: dataset(dataset)
 {
 	contexts.reserve(DeviceManager::get_device_count());
 	for (int i = 0; i < DeviceManager::get_device_count(); ++i) {
-		auto& nerf = nerf_proxy->nerfs[i];
+		
 		contexts.emplace_back(
-			DeviceManager::get_stream(i),
-			TrainingWorkspace(i),
+			DeviceManager::get_stream(i), 
+			TrainingWorkspace(i), 
 			&this->dataset,
-			&nerf,
+			&nerf_proxy->nerfs[i],
 			batch_size
-		);
+			);
 	}
 }
 

--- a/src/controllers/nerf-training-controller.h
+++ b/src/controllers/nerf-training-controller.h
@@ -21,7 +21,7 @@ NRC_NAMESPACE_BEGIN
 
 struct NeRFTrainingController {
 	// constructor
-	NeRFTrainingController(Dataset& dataset, NeRFProxy* nerf_proxy, const uint32_t& batch_size);
+	NeRFTrainingController(Dataset& dataset, NeRFProxy* nerf_proxy, const uint32_t batch_size);
 
 	// public properties
 

--- a/src/core/renderer.cuh
+++ b/src/core/renderer.cuh
@@ -18,12 +18,12 @@ struct Renderer {
 
         Context(
             const cudaStream_t& stream,
-            RenderingWorkspace& workspace,
-            const uint32_t& batch_size
+            RenderingWorkspace workspace,
+            uint32_t batch_size
         )
             : stream(stream)
-            , workspace(workspace)
-            , batch_size(batch_size)
+            , workspace(std::move(workspace))
+            , batch_size(std::move(batch_size))
         {};
     };
 

--- a/src/core/trainer.cuh
+++ b/src/core/trainer.cuh
@@ -34,17 +34,17 @@ public:
 
 		Context(
 			const cudaStream_t& stream,
-			TrainingWorkspace& workspace,
+			TrainingWorkspace workspace,
 			Dataset* dataset,
 			NeRF* nerf,
-			const uint32_t& batch_size
+			uint32_t batch_size
 		)
 			: stream(stream)
-			, workspace(workspace)
+			, workspace(std::move(workspace))
 			, dataset(dataset)
 			, nerf(nerf)
 			, batch_size(batch_size)
-			, n_rays_in_batch(batch_size)
+			, n_rays_in_batch(std::move(batch_size))
 			, n_samples_in_batch(0)
 		{
 			// TODO: CURAND_ASSERT_SUCCESS


### PR DESCRIPTION
Some more linux fixes. Pybind still does not build properly but at least the NerfRenderCore binary.
I removed some references at scalar datatypes as passing them by value tends to be faster. You can google it up or see for instance here: https://stackoverflow.com/questions/3009543/passing-integers-as-constant-references-versus-copying

I have to figure out the  Pybind issue. More to come in another pull request when I have managed it.