### PR TITLE
-XCompiler flag has to be followed by another flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ pybind11_add_module(PyNeRFRenderCore ${PYBIND_INCLUDES})
 
 # Set stricter compile flag
 if(NOT MSVC)
-	target_compile_options(${PROJECT_NAME} PRIVATE -Xcompiler)
+	target_compile_options(${PROJECT_NAME} PRIVATE -Xcompiler -Werror)
 endif()
 
 # CUDA includes / linkage


### PR DESCRIPTION
The -XCompiler flag cannot stand alone. We need to specify a following flag. -Werror turns warnings into errors. This helps to detect unused variables, for instance.