### PR TITLE
Fix GFLW include

### DIFF
--- a/src/integrations/blender.cuh
+++ b/src/integrations/blender.cuh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "../common.h"
-#include <glfw/glfw3.h>
+#include <GLFW/glfw3.h>
 
 NRC_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Please compare the include path of GLFW. In the includes, the glfw3.h is located under includes/glfw/include/**GLFW**/glfw3.h 
I suspect that cmake finds a random installation of glfw on your system. For me, the current include does not build because the path is not specified correctly.

Ok, last one for this evening :) Have a nice day.