### PR TITLE
Fix class qualification

### DIFF
--- a/src/core/renderer.cuh
+++ b/src/core/renderer.cuh
@@ -31,7 +31,7 @@ struct Renderer {
         RenderRequest& request
     );
 
-    void Renderer::write_to(
+    void write_to(
         Context& ctx,
         RenderTarget* target
     );


### PR DESCRIPTION
Build Fix. 
I wonder why this builds under windows at all if you use the class qualifier for a method within the class declaration.
Usually, you would use this only if you make a call to a static class method or if you explicitly call an overwritten class method but want the base class implementation. Otherwise, the compiler should complain. Whatever... now it build also under linux