### PR TITLE
writing rendering images in separate thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ set(NeRFRenderCore_LIBRARIES
 
 target_link_libraries(${PROJECT_NAME}
 	PRIVATE
+	-lpthread
 	${NeRFRenderCore_LIBRARIES}
 )
 

--- a/src/utils/gpu-image.cu
+++ b/src/utils/gpu-image.cu
@@ -5,6 +5,7 @@
 #include <stbi/stb_image.h>
 #include <stbi/stb_image_write.h>
 #include <vector>
+#include <memory>
 
 #include "parallel-utils.cuh"
 
@@ -16,11 +17,11 @@ __global__ void buffer_to_stbi_uc(
     stbi_uc* __restrict__ output,
     const float scale
 ) {
-	const uint32_t idx = blockDim.x * blockIdx.x + threadIdx.x;
+    const uint32_t idx = blockDim.x * blockIdx.x + threadIdx.x;
 
 	if (idx < n_elements) {
-		output[idx] = (stbi_uc)((float)input[idx] / scale * 255.0f);
-	}
+        output[idx] = (stbi_uc)((float)input[idx] / scale * 255.0f);
+    }
 }
 
 template <typename T>
@@ -35,9 +36,9 @@ __global__ void join_channels_kernel(
     if (pix_idx >= n_pixels) return;
 
     const uint32_t j_idx = n_channels * pix_idx;
-    
+
     uint32_t c_idx = pix_idx;
-    
+
     for (int i = 0; i < n_channels; ++i) {
         output[j_idx + i] = input[c_idx];
         c_idx += n_pixels;
@@ -50,20 +51,21 @@ void save_buffer_to_image(
     const float* data,
     const uint32_t& width,
     const uint32_t& height,
-    const uint32_t& channels,
+    const uint32_t channels,
+    std::thread& imgWriteThread,
     const uint32_t& stride,
     const float& scale
 ) {
     const uint32_t n_pixels = width * height;
-	const uint32_t n_elements = n_pixels * channels;
+    const uint32_t n_elements = n_pixels * channels;
 
-	tcnn::GPUMemory<stbi_uc> img_gpu(n_elements);
+    tcnn::GPUMemory<stbi_uc> img_gpu(n_elements);
     tcnn::GPUMemory<float> data_float(n_elements);
 
-    std::vector<stbi_uc> img_cpu(n_elements);
+    auto img_cpu = std::make_unique<std::vector<stbi_uc>>(n_elements);
 
     if (std::is_same<float, stbi_uc>::value) {
-        CUDA_CHECK_THROW(cudaMemcpyAsync(img_cpu.data(), data, n_elements * sizeof(stbi_uc), cudaMemcpyDeviceToHost, stream));
+        CUDA_CHECK_THROW(cudaMemcpyAsync((*img_cpu).data(), data, n_elements * sizeof(stbi_uc), cudaMemcpyDeviceToHost, stream));
     } else {
 
         copy_and_cast(stream, n_elements, data_float.data(), data);
@@ -73,13 +75,16 @@ void save_buffer_to_image(
         if (stride > 0) {
             tcnn::GPUMemory<stbi_uc> img_gpu_decontig(n_elements);
             join_channels_kernel<<<tcnn::n_blocks_linear(n_pixels), tcnn::n_threads_linear, 0, stream>>>(n_pixels, channels, img_gpu.data(), img_gpu_decontig.data());
-            img_gpu_decontig.copy_to_host(img_cpu);
+            img_gpu_decontig.copy_to_host(*img_cpu);
         } else {
-            img_gpu.copy_to_host(img_cpu);
+            img_gpu.copy_to_host(*img_cpu);
         }
     }
 
-	stbi_write_png(filename.c_str(), width, height, channels, img_cpu.data(), width * sizeof(stbi_uc) * channels);
+    auto f = [](std::string filename, uint32_t width, uint32_t height, uint32_t channels, std::unique_ptr<std::vector<stbi_uc>> imgcpu) {
+        stbi_write_png(filename.c_str(), width, height, channels, (*imgcpu).data(), width * sizeof(stbi_uc) * channels);
+    };
+    imgWriteThread = std::thread(f, filename, width, height, channels, std::move(img_cpu));
 }
 
 std::vector<float> save_buffer_to_memory(

--- a/src/utils/gpu-image.cuh
+++ b/src/utils/gpu-image.cuh
@@ -10,6 +10,7 @@
 
 #include <string>
 #include <vector>
+#include <thread>
 
 NRC_NAMESPACE_BEGIN
 
@@ -19,7 +20,8 @@ void save_buffer_to_image(
     const float* data,
     const uint32_t& width,
     const uint32_t& height,
-    const uint32_t& channels,
+    const uint32_t channels,
+    std::thread& imgWriteThread,
     const uint32_t& stride = 0,
     const float& scale = 1.0f
 );


### PR DESCRIPTION
Here is an suggestion to write the output images to disk in a separate thread.  The whole process output seems to me smoother so writing to disk should  not block anymore. 

I am not sure about the -lpthread flag. On linux, it is required to compile the <thread> dependency.
I am not sure but the file ending linux/windows stuff seems to mess up some lines of code that I did not touch or there is some formating in vs code working in the background. 

Please, just check it out and let me know, if this is something you like or if I should revise it or abandon.