### PR TITLE
Missing include: does not build

### DIFF
--- a/src/utils/queues.h
+++ b/src/utils/queues.h
@@ -8,6 +8,7 @@
 #include <future>
 #include <iostream>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 /**


### PR DESCRIPTION
This does not build. The include is missing and I believe that it does not come indirectly via another include.